### PR TITLE
Lowercased the Memecode, escaped captions

### DIFF
--- a/src/memes.coffee
+++ b/src/memes.coffee
@@ -63,9 +63,9 @@ module.exports = (robot) ->
 
   robot.respond /meme me (\w+) (\"[^"]+\") (\"[^"]+\")/i, (msg) ->
 
-    meme = if checkCode(msg.match[1], memes) then msg.match[1] else 'doge'
+    meme = if checkCode(msg.match[1].toLowerCase(), memes) then msg.match[1].toLowerCase() else 'doge'
     top    = msg.match[2].replace(/"/g, '').trim().replace(/\s+/g, '-')
     bottom = msg.match[3].replace(/"/g, '').trim().replace(/\s+/g, '-')
 
-    msg.send "http://memegen.link/#{meme}/#{top}/#{bottom}.jpg"
+    msg.send "http://memegen.link/#{meme}/#{escape(top)}/#{escape(bottom)}.jpg"
 


### PR DESCRIPTION
Lowercased the Memecode, allowing for mixed case entry. Because iPhone always wants to capitalize Morpheus. 

Also escaped captions in URL entry. Makes URLS less human readable at times, but allows for functioning punctuation.
