### PR TITLE
Added fix for mac OSX changing double quotes into non-standard characters

### DIFF
--- a/src/memes.coffee
+++ b/src/memes.coffee
@@ -89,11 +89,9 @@ module.exports = (robot) ->
     for code, meme of memes
       msg.send "http://memegen.link/#{code}/#{escape(code)}/#{escape(meme)}.jpg"
 
-  robot.respond /meme me (\w+) (\"[^"]+\") (\"[^"]+\")/i, (msg) ->
-
+  robot.respond /meme me (\w+) ([\"\“\”][^\"\“\”]+[\"\“\”]) ([\"\“\”][^\"\“\”]+[\"\“\”])/i, (msg) ->
     meme = if checkCode(msg.match[1].toLowerCase(), memes) then msg.match[1].toLowerCase() else 'doge'
-    top    = msg.match[2].replace(/"/g, '').trim().replace(/\s+/g, '-')
-    bottom = msg.match[3].replace(/"/g, '').trim().replace(/\s+/g, '-')
+    top    = msg.match[2].replace(/"|“|”/g, '').trim().replace(/\s+/g, '-')
+    bottom = msg.match[3].replace(/"|“|”/g, '').trim().replace(/\s+/g, '-')
 
     msg.send "http://memegen.link/#{meme}/#{escape(top)}/#{escape(bottom)}.jpg"
-

--- a/test/memes_test.coffee
+++ b/test/memes_test.coffee
@@ -13,7 +13,7 @@ describe 'memes', ->
     require('../src/memes')(@robot)
 
   it 'registers a respond listener', ->
-    expect(@robot.respond).to.have.been.calledWith(/meme me (\w+) (\"[^"]+\") (\"[^"]+\")/i)
+    expect(@robot.respond).to.have.been.calledWith(/meme me (\w+) ([\"\“\”][^\"\“\”]+[\"\“\”]) ([\"\“\”][^\"\“\”]+[\"\“\”])/i)
 
   it 'registers a hear listener to the list command', ->
     expect(@robot.respond).to.have.been.calledWith(/meme list/i)


### PR DESCRIPTION
Hi there,
I love the idea of this hubot plugin but was disappointed when I could not get it working in my environment (Mac OSX + Slack + hubot).  Problem was that Mac OSX was changing the double quote characters to ones that were not captured by the implemented regex expressions.  

With the regex expressions now allowing for non-standard double-quote characters used by OSX, I'm able to get hubot creating memes in Slack.
