### PR TITLE
Replace "’" with "'" when generating meme text.

### DIFF
--- a/src/memes.coffee
+++ b/src/memes.coffee
@@ -106,7 +106,7 @@ module.exports = (robot) ->
 
   robot.respond /meme me (\w+) ([\"\“\”][^\"\“\”]+[\"\“\”]) ([\"\“\”][^\"\“\”]+[\"\“\”])/i, (msg) ->
     meme = if checkCode(msg.match[1].toLowerCase(), memes) then msg.match[1].toLowerCase() else 'doge'
-    top    = msg.match[2].replace(/"|“|”/g, '').trim().replace(/\s+/g, '-')
-    bottom = msg.match[3].replace(/"|“|”/g, '').trim().replace(/\s+/g, '-')
+    top    = msg.match[2].replace(/"|“|”/g, '').trim().replace(/\s+/g, '-').replace(/\’/g, '\'')
+    bottom = msg.match[3].replace(/"|“|”/g, '').trim().replace(/\s+/g, '-').replace(/\’/g, '\'')
 
     msg.send "http://memegen.link/#{meme}/#{escape(top)}/#{escape(bottom)}.jpg"


### PR DESCRIPTION
When using this plugin on OSX with Slack, OSX kept changing single quote (apostrophe character) into the special character "’".  This resulted in a broken image when using the meme generator with an apostrophe.
![image](https://cloud.githubusercontent.com/assets/8252744/15190443/8201d7e4-1775-11e6-9582-9eb058330de6.png)
This pull request will replace "’" with "'" and should fix this bug.
