### PR TITLE
Refactor 'meme show' command to avoid hitting Slack rate limit

### DIFF
--- a/src/memes.coffee
+++ b/src/memes.coffee
@@ -101,8 +101,9 @@ module.exports = (robot) ->
     msg.send memelist
 
   robot.respond /meme show/i, (msg) ->
-    for code, meme of memes
-      msg.send "http://memegen.link/#{code}/#{escape(code)}/#{escape(meme)}.jpg"
+    memelist = ''
+    memelist += "http://memegen.link/#{code}/#{escape(code)}/#{escape(meme)}.jpg\n" for code, meme of memes 
+    msg.send memelist
 
   robot.respond /meme me (\w+) ([\"\“\”][^\"\“\”]+[\"\“\”]) ([\"\“\”][^\"\“\”]+[\"\“\”])/i, (msg) ->
     meme = if checkCode(msg.match[1].toLowerCase(), memes) then msg.match[1].toLowerCase() else 'doge'


### PR DESCRIPTION
The 'meme show' command for loop was causing hubot to hit the Slack API rate limit.  Sending all of the meme examples as one chunk of text should avoid this.
